### PR TITLE
Check if class is found, and if not write error message and exit

### DIFF
--- a/fix_bag_msg_def.py
+++ b/fix_bag_msg_def.py
@@ -116,6 +116,9 @@ def main():
             # don't have mapping, but are allowed to use local msg def: retrieve
             # TODO: properly deal with get_message_class failing
             sys_class = roslib.message.get_message_class(msg_type)
+            if sys_class is None:
+                print("Message class '" + msg_type + "' not found.")
+                exit(1)
             msg_def_maps[conx.datatype] = sys_class._full_text
 
         # here, we either already had a mapping or one was just created

--- a/fix_bag_msg_def.py
+++ b/fix_bag_msg_def.py
@@ -117,8 +117,7 @@ def main():
             # TODO: properly deal with get_message_class failing
             sys_class = roslib.message.get_message_class(msg_type)
             if sys_class is None:
-                print("Message class '" + msg_type + "' not found.")
-                exit(1)
+                raise ValueError("Message class '" + msg_type + "' not found.")
             msg_def_maps[conx.datatype] = sys_class._full_text
 
         # here, we either already had a mapping or one was just created


### PR DESCRIPTION
Shows helpful message which class can't be found rather than exiting on `sys_class._full_text` not found.